### PR TITLE
テキストのテクスチャをキャッシュして高速化

### DIFF
--- a/src/view/gameview.rs
+++ b/src/view/gameview.rs
@@ -92,13 +92,12 @@ impl GameView {
         message: e.to_string(),
       })?;
 
-    let builder = TextBuilder::new(&font, &texture_creator);
-
     let mut timer = self
       .ctx
       .timer()
       .map_err(|e| ViewError::InitError { message: e })?;
 
+    let mut builder = TextBuilder::new(&font, &texture_creator);
     let mut mt_events = vec![];
     let mut musics = vec![];
     let mut pressed_key_buf = BTreeSet::new();
@@ -165,7 +164,7 @@ impl GameView {
       whole::render(
         &mut self.canvas,
         sdl2::rect::Rect::new(0, 0, self.width, self.height),
-        builder.clone(),
+        &mut builder,
         &WholeProps {
           pressed_keys: &pressed_key_buf
             .iter()
@@ -194,9 +193,9 @@ impl GameView {
       mt_events =
         self.model.key_press(typed_key_buf_cloned.into_iter());
 
+      let elapsed = time.elapsed().as_secs_f64();
       timer.delay((1e3 / 60.0) as u32);
 
-      let elapsed = time.elapsed().as_secs_f64();
       mt_events.append(&mut self.model.elapse_time(elapsed));
       print!(
         "\rFPS: {}, Playing: {}     ",

--- a/src/view/gameview.rs
+++ b/src/view/gameview.rs
@@ -193,13 +193,16 @@ impl GameView {
       mt_events =
         self.model.key_press(typed_key_buf_cloned.into_iter());
 
-      let elapsed = time.elapsed().as_secs_f64();
+      let draw_time = time.elapsed().as_secs_f64();
+
       timer.delay((1e3 / 60.0) as u32);
+
+      let elapsed = time.elapsed().as_secs_f64();
 
       mt_events.append(&mut self.model.elapse_time(elapsed));
       print!(
         "\rFPS: {}, Playing: {}     ",
-        1.0 / elapsed,
+        1.0 / draw_time,
         sdl2::mixer::Music::is_playing()
       );
     }

--- a/src/view/gameview/whole.rs
+++ b/src/view/gameview/whole.rs
@@ -34,13 +34,13 @@ pub fn render<'a, 't>(
 
   {
     let header =
-        Header::new(props.title, props.song_author, props.score_point);
+      Header::new(props.title, props.song_author, props.score_point);
     let header_dim = Rect::new(0, 0, client.width(), 100);
     header.draw(&mut canvas, builder)?;
     canvas.set_draw_color(Color::RGB(0, 0, 0));
     canvas
-        .draw_rect(header_dim)
-        .map_err(|e| ViewError::RenderError(e))?;
+      .draw_rect(header_dim)
+      .map_err(|e| ViewError::RenderError(e))?;
   }
 
   {
@@ -49,20 +49,20 @@ pub fn render<'a, 't>(
     finder.draw(&mut canvas, builder, finder_dim)?;
     canvas.set_draw_color(Color::RGB(0, 0, 0));
     canvas
-        .draw_rect(finder_dim)
-        .map_err(|e| ViewError::RenderError(e))?;
+      .draw_rect(finder_dim)
+      .map_err(|e| ViewError::RenderError(e))?;
   }
 
   {
     let keyboard = Keyboard::new(props.pressed_keys, &[]);
     let keyboard_dim =
-        Rect::new(0, client.height() as i32 - 300, client.width(), 300);
+      Rect::new(0, client.height() as i32 - 300, client.width(), 300);
     keyboard.draw(&mut canvas, builder, keyboard_dim)?;
 
     canvas.set_draw_color(Color::RGB(0, 0, 0));
     canvas
-        .draw_rect(keyboard_dim)
-        .map_err(|e| ViewError::RenderError(e))?;
+      .draw_rect(keyboard_dim)
+      .map_err(|e| ViewError::RenderError(e))?;
   }
 
   Ok(())

--- a/src/view/gameview/whole.rs
+++ b/src/view/gameview/whole.rs
@@ -26,39 +26,44 @@ pub struct WholeProps<'a> {
 pub fn render<'a, 't>(
   mut canvas: &mut Canvas<Window>,
   client: Rect,
-  builder: TextBuilder<'t, WindowContext>,
+  builder: &mut TextBuilder<'t, WindowContext>,
   props: &'a WholeProps,
 ) -> Result<(), ViewError> {
-  let header =
-    Header::new(props.title, props.song_author, props.score_point);
-  let header_dim = Rect::new(0, 0, client.width(), 100);
-
-  let finder = Finder::new(props.sentence, 0.2);
-  let finder_dim = Rect::new(0, 100, client.width(), 200);
-
-  let keyboard = Keyboard::new(props.pressed_keys, &[]);
-  let keyboard_dim =
-    Rect::new(0, client.height() as i32 - 300, client.width(), 300);
-
   canvas.set_draw_color(Color::RGB(253, 243, 226));
   canvas.clear();
 
-  header.draw(&mut canvas, builder.clone())?;
-  canvas.set_draw_color(Color::RGB(0, 0, 0));
-  canvas
-    .draw_rect(header_dim)
-    .map_err(|e| ViewError::RenderError(e))?;
+  {
+    let header =
+        Header::new(props.title, props.song_author, props.score_point);
+    let header_dim = Rect::new(0, 0, client.width(), 100);
+    header.draw(&mut canvas, builder)?;
+    canvas.set_draw_color(Color::RGB(0, 0, 0));
+    canvas
+        .draw_rect(header_dim)
+        .map_err(|e| ViewError::RenderError(e))?;
+  }
 
-  finder.draw(&mut canvas, builder.clone(), finder_dim)?;
-  canvas.set_draw_color(Color::RGB(0, 0, 0));
-  canvas
-    .draw_rect(finder_dim)
-    .map_err(|e| ViewError::RenderError(e))?;
+  {
+    let finder = Finder::new(props.sentence, 0.2);
+    let finder_dim = Rect::new(0, 100, client.width(), 200);
+    finder.draw(&mut canvas, builder, finder_dim)?;
+    canvas.set_draw_color(Color::RGB(0, 0, 0));
+    canvas
+        .draw_rect(finder_dim)
+        .map_err(|e| ViewError::RenderError(e))?;
+  }
 
-  keyboard.draw(&mut canvas, builder.clone(), keyboard_dim)?;
-  canvas.set_draw_color(Color::RGB(0, 0, 0));
-  canvas
-    .draw_rect(keyboard_dim)
-    .map_err(|e| ViewError::RenderError(e))?;
+  {
+    let keyboard = Keyboard::new(props.pressed_keys, &[]);
+    let keyboard_dim =
+        Rect::new(0, client.height() as i32 - 300, client.width(), 300);
+    keyboard.draw(&mut canvas, builder, keyboard_dim)?;
+
+    canvas.set_draw_color(Color::RGB(0, 0, 0));
+    canvas
+        .draw_rect(keyboard_dim)
+        .map_err(|e| ViewError::RenderError(e))?;
+  }
+
   Ok(())
 }

--- a/src/view/gameview/whole/finder.rs
+++ b/src/view/gameview/whole/finder.rs
@@ -22,10 +22,10 @@ impl<'a> Finder<'a> {
     }
   }
 
-  pub fn draw<T: RenderTarget, U>(
+  pub fn draw<'builder, T: RenderTarget, U>(
     &self,
     mut canvas: &mut Canvas<T>,
-    mut text_builder: TextBuilder<'a, U>,
+    mut text_builder: &mut TextBuilder<'builder, U>,
     offset: Rect,
   ) -> Result<(), TextError> {
     let remaining_width =

--- a/src/view/gameview/whole/header.rs
+++ b/src/view/gameview/whole/header.rs
@@ -21,43 +21,54 @@ impl Header {
   pub fn draw<'a, T: RenderTarget, U>(
     &self,
     mut canvas: &mut Canvas<T>,
-    mut text_builder: TextBuilder<'a, U>,
+    mut text_builder: &mut TextBuilder<'a, U>,
   ) -> Result<(), TextError> {
     const JAPANESE_GLYPH_WIDTH: u32 = 13;
     use sdl2::pixels::Color;
-    let title_text =
-      text_builder.text(self.title.as_str()).build()?;
-    let author_text = text_builder
-      .text(self.author.as_str())
-      .color(Color::RGB(156, 156, 162))
-      .build()?;
-    let score_text = text_builder
-      .text(format!("{:08}", self.score_point).as_str())
-      .color(Color::RGB(64, 79, 181))
-      .build()?;
-    let title_text_width =
-      self.title.len() as u32 * JAPANESE_GLYPH_WIDTH;
-    title_text.render(
-      &mut canvas,
-      Rect::new(
-        800 - title_text_width as i32,
-        0,
-        title_text_width,
-        50,
-      ),
-    )?;
-    let author_text_width =
-      self.author.len() as u32 * JAPANESE_GLYPH_WIDTH;
-    author_text.render(
-      &mut canvas,
-      Rect::new(
-        800 - author_text_width as i32,
-        50,
-        author_text_width,
-        50,
-      ),
-    )?;
-    score_text.render(&mut canvas, Rect::new(0, 50, 300, 50))?;
+
+    {
+      let title_text =
+          text_builder.text(self.title.as_str()).build()?;
+      let title_text_width =
+          self.title.len() as u32 * JAPANESE_GLYPH_WIDTH;
+      title_text.render(
+        &mut canvas,
+        Rect::new(
+          800 - title_text_width as i32,
+          0,
+          title_text_width,
+          50,
+        ),
+      )?;
+    }
+
+    {
+      let author_text = text_builder
+          .text(self.author.as_str())
+          .color(Color::RGB(156, 156, 162))
+          .build()?;
+      let author_text_width =
+          self.author.len() as u32 * JAPANESE_GLYPH_WIDTH;
+      author_text.render(
+        &mut canvas,
+        Rect::new(
+          800 - author_text_width as i32,
+          50,
+          author_text_width,
+          50,
+        ),
+      )?;
+    }
+
+    {
+      let score_text = text_builder
+          .text(format!("{:08}", self.score_point).as_str())
+          .color(Color::RGB(64, 79, 181))
+          .build()?;
+
+      score_text.render(&mut canvas, Rect::new(0, 50, 300, 50))?;
+    }
+
     Ok(())
   }
 }

--- a/src/view/gameview/whole/header.rs
+++ b/src/view/gameview/whole/header.rs
@@ -28,9 +28,9 @@ impl Header {
 
     {
       let title_text =
-          text_builder.text(self.title.as_str()).build()?;
+        text_builder.text(self.title.as_str()).build()?;
       let title_text_width =
-          self.title.len() as u32 * JAPANESE_GLYPH_WIDTH;
+        self.title.len() as u32 * JAPANESE_GLYPH_WIDTH;
       title_text.render(
         &mut canvas,
         Rect::new(
@@ -44,11 +44,11 @@ impl Header {
 
     {
       let author_text = text_builder
-          .text(self.author.as_str())
-          .color(Color::RGB(156, 156, 162))
-          .build()?;
+        .text(self.author.as_str())
+        .color(Color::RGB(156, 156, 162))
+        .build()?;
       let author_text_width =
-          self.author.len() as u32 * JAPANESE_GLYPH_WIDTH;
+        self.author.len() as u32 * JAPANESE_GLYPH_WIDTH;
       author_text.render(
         &mut canvas,
         Rect::new(
@@ -62,9 +62,9 @@ impl Header {
 
     {
       let score_text = text_builder
-          .text(format!("{:08}", self.score_point).as_str())
-          .color(Color::RGB(64, 79, 181))
-          .build()?;
+        .text(format!("{:08}", self.score_point).as_str())
+        .color(Color::RGB(64, 79, 181))
+        .build()?;
 
       score_text.render(&mut canvas, Rect::new(0, 50, 300, 50))?;
     }

--- a/src/view/gameview/whole/keyboard.rs
+++ b/src/view/gameview/whole/keyboard.rs
@@ -114,7 +114,7 @@ impl Keyboard {
           self.highlighted_keys.contains(&key_char),
           self.pressed_keys.contains(&key_char),
         );
-          cell.draw(&mut canvas, text_builder)?;
+        cell.draw(&mut canvas, text_builder)?;
         x += 1;
       }
       y += 1;

--- a/src/view/gameview/whole/keyboard.rs
+++ b/src/view/gameview/whole/keyboard.rs
@@ -32,7 +32,7 @@ impl KeyCell {
   pub fn draw<'a, T: RenderTarget, U>(
     self,
     mut canvas: &mut Canvas<T>,
-    mut text_builder: TextBuilder<'a, U>,
+    mut text_builder: &mut TextBuilder<'a, U>,
   ) -> Result<(), TextError> {
     const ORANGE: Color = Color::RGB(209, 154, 29);
     const GREEN: Color = Color::RGB(20, 76, 64);
@@ -90,7 +90,7 @@ impl Keyboard {
   pub fn draw<'a, T: RenderTarget, U>(
     &self,
     mut canvas: &mut Canvas<T>,
-    text_builder: TextBuilder<'a, U>,
+    text_builder: &mut TextBuilder<'a, U>,
     offset: Rect,
   ) -> Result<(), TextError> {
     let key_chars_rows =
@@ -114,9 +114,7 @@ impl Keyboard {
           self.highlighted_keys.contains(&key_char),
           self.pressed_keys.contains(&key_char),
         );
-        {
-          cell.draw(&mut canvas, text_builder.clone())?;
-        }
+          cell.draw(&mut canvas, text_builder)?;
         x += 1;
       }
       y += 1;


### PR DESCRIPTION
ライフタイムとスコープを見直したところ、別にBuilderをたらい回ししなくても、普通に可変借用することでTextBuilderを1個にできました。

40 ~  120FPS -> 500FPS前後にまでパフォーマンスが改善します。